### PR TITLE
chore: add support for `import foreign schema`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.26.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c7526379ace8709ee9ab9f2bb50f112d95581063a59ef3097d9c10153886c9"
+checksum = "c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ strip = "debuginfo"
 lto = true
 
 [dependencies]
-wit-bindgen-rt = "0.26.0"
+wit-bindgen-rt = "0.41.0"
 serde_json = "1.0"
 sha2 = "0.10"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ impl Guest for GravatarFdw {
                     interests jsonb,
                     payments jsonb,
                     contact_info jsonb,
-                    number_verified_accounts bigint,
+                    number_verified_accounts int,
                     last_profile_edit timestamp,
                     registration_date timestamp,
                     json jsonb

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl Guest for GravatarFdw {
                     pronunciation text,
                     pronouns text,
                     timezone text,
-                    language jsonb,
+                    languages jsonb,
                     first_name text,
                     last_name text,
                     is_organization boolean,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ impl Guest for GravatarFdw {
                     number_verified_accounts bigint,
                     last_profile_edit timestamp,
                     registration_date timestamp,
-                    attrs jsonb
+                    json jsonb
                 )
                 server {} options (
                     table 'profiles'

--- a/supabase-wrappers-wit/routines.wit
+++ b/supabase-wrappers-wit/routines.wit
@@ -1,6 +1,6 @@
 interface routines {
     use types.{
-        cell, row, context, fdw-error, fdw-result,
+        cell, row, import-foreign-schema-stmt, context, fdw-error, fdw-result,
     };
 
     // ----------------------------------------------
@@ -32,4 +32,10 @@ interface routines {
     ) -> fdw-result;
     delete: func(ctx: borrow<context>, rowid: cell) -> fdw-result;
     end-modify: func(ctx: borrow<context>) -> fdw-result;
+
+    // import foreign schema
+    import-foreign-schema: func(
+        ctx: borrow<context>,
+        stmt: import-foreign-schema-stmt,
+    ) -> result<list<string>, fdw-error>;
 }

--- a/supabase-wrappers-wit/types.wit
+++ b/supabase-wrappers-wit/types.wit
@@ -13,6 +13,8 @@ interface types {
         timestamp,
         timestamptz,
         json,
+        uuid,
+        other(string),
     }
 
     variant cell {
@@ -31,6 +33,8 @@ interface types {
         timestamp(s64),
         timestamptz(s64),
         json(string),
+        uuid(string),
+        other(string),
     }
 
     resource row {
@@ -97,6 +101,8 @@ interface types {
     variant options-type {
         server,
         table,
+        import-schema,
+        other(string),
     }
 
     resource options {
@@ -105,6 +111,20 @@ interface types {
         get: func(key: string) -> option<string>;
         require: func(key: string) -> result<string, fdw-error>;
         require-or: func(key: string, default: string) -> string;
+    }
+
+    variant import-schema-type {
+        all,
+        limit-to,
+        except,
+    }
+
+    record import-foreign-schema-stmt {
+        server-name: string,
+        remote-schema: string,
+        local-schema: string,
+        list-type: import-schema-type,
+        table-list: list<string>,
     }
 
     resource context {

--- a/supabase-wrappers-wit/world.wit
+++ b/supabase-wrappers-wit/world.wit
@@ -1,4 +1,4 @@
-package supabase:wrappers@0.1.0;
+package supabase:wrappers@0.2.0;
 
 world wrappers {
     import http;

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,10 +1,10 @@
 package automattic:gravatar-fdw@0.1.0;
 
 world gravatar {
-    import supabase:wrappers/http@0.1.0;
-    import supabase:wrappers/jwt@0.1.0;
-    import supabase:wrappers/stats@0.1.0;
-    import supabase:wrappers/time@0.1.0;
-    import supabase:wrappers/utils@0.1.0;
-    export supabase:wrappers/routines@0.1.0;
+    import supabase:wrappers/http@0.2.0;
+    import supabase:wrappers/jwt@0.2.0;
+    import supabase:wrappers/stats@0.2.0;
+    import supabase:wrappers/time@0.2.0;
+    import supabase:wrappers/utils@0.2.0;
+    export supabase:wrappers/routines@0.2.0;
 }


### PR DESCRIPTION
This PR is to add `import foreign schema` support for this wrapper. To support that feature, the wit version has also been upgraded to 0.2.0. After this PR is merged, can we release a new version so we can add it as a community wrapper to [Supabase Wrappers Catalog](https://fdw.dev/catalog/)?