### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -45,7 +45,7 @@ jobs:
           cargo component build --release --target wasm32-unknown-unknown
 
       - name: Calculate Wasm file checksum
-        uses: jmgilman/actions-generate-checksum@d4c0e5a3805ae266f169d05a2542c66968d5ec83 # v1.0.1
+        uses: jmgilman/actions-generate-checksum@3ea6dc9bf8eecf28e2ecc982fab683484a1a8561 # v1.0.1
         with:
           method: sha256
           output: checksum.txt

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -45,7 +45,7 @@ jobs:
           cargo component build --release --target wasm32-unknown-unknown
 
       - name: Calculate Wasm file checksum
-        uses: jmgilman/actions-generate-checksum@v1
+        uses: jmgilman/actions-generate-checksum@238073f4c02f2810adb91c96bdd1e276a5ae9ed6 # v1
         with:
           method: sha256
           output: checksum.txt

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -45,7 +45,7 @@ jobs:
           cargo component build --release --target wasm32-unknown-unknown
 
       - name: Calculate Wasm file checksum
-        uses: jmgilman/actions-generate-checksum@238073f4c02f2810adb91c96bdd1e276a5ae9ed6 # v1
+        uses: jmgilman/actions-generate-checksum@d4c0e5a3805ae266f169d05a2542c66968d5ec83 # v1.0.1
         with:
           method: sha256
           output: checksum.txt

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           make_latest: true

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           make_latest: true


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. Add Dependabot `github-actions` config (weekly, grouped into `actions-minor-patch` and `actions-major`, with cooldown).

Tracking: DEVPROD-1072.

_Pin partial: 1/2 refs resolved; remainder use moving branch refs and need manual pinning._
